### PR TITLE
chore(renovate): Add renovate group for @birthdayresearch/sticky

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,6 +33,10 @@
     {
       "matchPackagePatterns": ["^@birthdayresearch/contented"],
       "groupName": "@birthdayresearch/contented"
+    },
+    {
+      "matchPackagePatterns": ["^@birthdayresearch/sticky-"],
+      "groupName": "@birthdayresearch/sticky"
     }
   ]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
As per title. Groups the @birthdayresearch/sticky- packages since they are always bumped together. Leaving them ungrouped will only cause PR bloat from the dependency bumps by renovate


<!--
* If applicable
-->
