### PR TITLE
chore(contracts): Add Hardhat task for better  dApp integration devx

### DIFF
--- a/packages/smartcontracts/README.md
+++ b/packages/smartcontracts/README.md
@@ -1,0 +1,16 @@
+# smartcontracts
+
+A package which contains the Ethereum smart contracts for the DeFiChain to Ethereum bridge.
+
+## Setting up local environment
+
+This section outlines how to get started on integrating with the smart contracts for the Bridge on your dApp.
+There are many different ways, but this is the simplest and fastest method.
+
+1. In your terminal, run `npx hardhat --config ./src/hardhat.config.ts node` from this package's directory
+   - This runs a new Hardhat node locally, listening on `http://127.0.0.1:8545`
+2. In another terminal, run `npx hardhat --config ./src/hardhat.config.ts --network localhost setupLocalTestnet`
+   - This will deploy the smart contracts to the local Hardhat node that you have started
+   - This command will also log out the different contract addresses, and the minted tokens
+
+You're done! Your dApp can now interact with the smart contracts on the local Hardhat node.

--- a/packages/smartcontracts/package.json
+++ b/packages/smartcontracts/package.json
@@ -15,7 +15,7 @@
     "test:hardhat": "pnpm run generate:contract-types && hardhat test --config ./src/hardhat.config.ts",
     "clean": "rm -rf dist && rm -f tsconfig.build.tsbuildinfo && hardhat clean --config ./src/hardhat.config.ts",
     "generate:contract-types": "hardhat compile --config ./src/hardhat.config.ts",
-    "lint": "eslint ."
+    "lint": "eslint . --fix"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/smartcontracts/src/hardhat.config.ts
+++ b/packages/smartcontracts/src/hardhat.config.ts
@@ -5,7 +5,6 @@ import '@nomiclabs/hardhat-etherscan';
 import { HardhatUserConfig, task, types } from 'hardhat/config';
 
 import { TX_AUTOMINE_ENV_VAR, TX_AUTOMINE_INTERVAL_ENV_VAR } from './envvar';
-import { BridgeV1__factory } from './generated';
 
 // Default chainId for local testing purposes. Most local testnets (Ganache, etc) use this chainId
 export const DEFAULT_CHAINID = 1337;
@@ -91,7 +90,7 @@ task('setupLocalTestnet', 'Sets up all the contracts necessary for dApp integrat
     console.log('BridgeV1 implementation deployed. You do not need to worry about the address of this contract.');
 
     const BridgeProxy = await hre.ethers.getContractFactory('BridgeProxy');
-    const encodedData = BridgeV1__factory.createInterface().encodeFunctionData('initialize', [
+    const encodedData = BridgeV1.interface.encodeFunctionData('initialize', [
       'CAKE_BRIDGE',
       '1',
       // admin address

--- a/packages/smartcontracts/src/hardhat.config.ts
+++ b/packages/smartcontracts/src/hardhat.config.ts
@@ -5,6 +5,7 @@ import '@nomiclabs/hardhat-etherscan';
 import { HardhatUserConfig, task, types } from 'hardhat/config';
 
 import { TX_AUTOMINE_ENV_VAR, TX_AUTOMINE_INTERVAL_ENV_VAR } from './envvar';
+import { BridgeV1__factory } from './generated';
 
 // Default chainId for local testing purposes. Most local testnets (Ganache, etc) use this chainId
 export const DEFAULT_CHAINID = 1337;
@@ -57,6 +58,77 @@ task('deployContract', 'Deploys a contract based on the name of the contract')
       console.log(e);
     }
   });
+
+task('setupLocalTestnet', 'Sets up all the contracts necessary for dApp integration.').setAction(
+  async (taskArgs, hre) => {
+    // suppressing type error - method is actually properly typed
+    // @ts-ignore
+    const [defaultNodeSigner] = await hre.ethers.getSigners();
+    const eoaAddress = defaultNodeSigner.address;
+    console.log(`Please use ${eoaAddress} as your address for testing with Hardhat`);
+
+    // Deploy the ERC20 tokens
+    const ERC20 = await hre.ethers.getContractFactory('TestToken');
+    const mockTokenUSDT = await ERC20.deploy('MockUSDT', 'MUSDT');
+    await mockTokenUSDT.deployed();
+    console.log('Test token MUSDT is deployed to ', mockTokenUSDT.address);
+
+    const mockTokenUSDC = await ERC20.deploy('MockUSDC', 'MUSDC');
+    await mockTokenUSDC.deployed();
+    console.log('Test token MUSDC is deployed to ', mockTokenUSDC.address);
+
+    // Mint tokens to EOA
+    await mockTokenUSDT.mint(eoaAddress, 1_000_000_000);
+    console.log(`Minted 1,000,000,000 MUSDT tokens to ${eoaAddress}`);
+
+    await mockTokenUSDC.mint(eoaAddress, 1_000_000_000);
+    console.log(`Minted 1,000,000,000 MUSDC tokens to ${eoaAddress}`);
+
+    // Deploy Bridge implementation contract
+    const BridgeV1 = await hre.ethers.getContractFactory('BridgeV1');
+    const bridgeV1 = await BridgeV1.deploy();
+    await bridgeV1.deployed();
+    console.log('BridgeV1 implementation deployed. You do not need to worry about the address of this contract.');
+
+    const BridgeProxy = await hre.ethers.getContractFactory('BridgeProxy');
+    const encodedData = BridgeV1__factory.createInterface().encodeFunctionData('initialize', [
+      'CAKE_BRIDGE',
+      '1',
+      // admin address
+      eoaAddress,
+      // operational address
+      eoaAddress,
+      // relayer address - set to AddressZero for now, since we are not worried about DFC -> ETH flow yet
+      hre.ethers.constants.AddressZero,
+      // 0.3% fee
+      30,
+    ]);
+    const bridgeProxy = await BridgeProxy.deploy(bridgeV1.address, encodedData);
+    await bridgeProxy.deployed();
+
+    console.log(`BridgeProxy deployed to ${bridgeProxy.address} You will need to use this address for testing.`);
+    console.log(`${eoaAddress} has been set as the operational address and admin address.`);
+
+    // Add the tokens as supported tokens to the bridge
+    const bridgeProxyContract = BridgeV1.attach(bridgeProxy.address);
+    await bridgeProxyContract.addSupportedTokens(
+      mockTokenUSDT.address,
+      hre.ethers.constants.MaxInt256,
+      // current timestamp
+      Math.floor(Date.now() / 1000),
+    );
+    await bridgeProxyContract.addSupportedTokens(
+      mockTokenUSDC.address,
+      hre.ethers.constants.MaxInt256,
+      // current timestamp
+      Math.floor(Date.now() / 1000),
+    );
+
+    console.log(
+      `MUSDT and MUSDC have been added as supported tokens to the bridge, with daily allowance set to MaxInt256`,
+    );
+  },
+);
 
 // You need to export an object to set up your config
 // Go to https://hardhat.org/config/ to learn more

--- a/packages/smartcontracts/src/tests/SetupLocalTestTask.spec.ts
+++ b/packages/smartcontracts/src/tests/SetupLocalTestTask.spec.ts
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+import { ethers, run } from 'hardhat';
+
+import { BridgeV1__factory, TestToken__factory } from '../generated';
+
+describe('SetupLocalTestTask', () => {
+  it('should set up the expected local testnet state', async () => {
+    // Given that the setupLocalTest task is run
+    await run('setupLocalTestnet');
+    // snapshot current time - potentially flaky, but not possible to get the exact timestamp
+    // unless we return it from the task
+    const expectedTimeStamp = Math.floor(Date.now() / 1000);
+
+    // suppressing type error - method is actually properly typed
+    // @ts-ignore
+    const [eoaSigner] = await ethers.getSigners();
+    const eoaAddress = eoaSigner.address;
+    // since the tests are deterministic, the contract addresses are deterministic as well
+    // we can technically return these from the task, but it's not worth the effort for now
+    // if this becomes a problem, we'll need to return the addresses/contract instances from the task
+    const musdtAddress = '0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9';
+    const musdcAddress = '0x5FC8d32690cc91D4c39d9d3abcBD16989F875707';
+    const bridgeProxyAddress = '0x8A791620dd6260079BF849Dc5567aDC3F2FdC318';
+
+    const musdtContract = TestToken__factory.connect(musdtAddress, eoaSigner);
+    const musdcContract = TestToken__factory.connect(musdcAddress, eoaSigner);
+    // behind proxy, so we need to use the proxy address
+    const bridgeContract = BridgeV1__factory.connect(bridgeProxyAddress, eoaSigner);
+
+    // When checking the ERC20 balances of the EOA
+    const musdtBalance = await musdtContract.balanceOf(eoaAddress);
+    const musdcBalance = await musdcContract.balanceOf(eoaAddress);
+
+    // Then the balances should be as expected
+    expect(musdtBalance.eq(1_000_000_000)).to.equal(true);
+    expect(musdcBalance.eq(1_000_000_000)).to.equal(true);
+
+    // When checking the admin address of the bridge
+    // Then the EOA account should have the admin role.
+    const DEFAULT_ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000';
+    expect(await bridgeContract.hasRole(DEFAULT_ADMIN_ROLE, eoaAddress)).to.equal(true);
+
+    // When checking the operational address of the bridge
+    // Then the EOA account should have the operational role.
+    const OPERATIONAL_ROLE = ethers.utils.solidityKeccak256(['string'], ['OPERATIONAL_ROLE']);
+    expect(await bridgeContract.hasRole(OPERATIONAL_ROLE, eoaAddress)).to.equal(true);
+
+    // When checking that MUSDT is supported on the bridge
+    // Then the token should be supported
+    expect(await bridgeContract.supportedTokens(musdtAddress)).to.equal(true);
+    const musdtSupportedTokenInfo = await bridgeContract.tokenAllowances(musdtAddress);
+
+    // And the token should have the expected reset time
+    expect(musdtSupportedTokenInfo[0].eq(expectedTimeStamp)).to.equal(true);
+
+    // And the token should have the expected daily allowance
+    expect(musdtSupportedTokenInfo[1].eq(ethers.constants.MaxInt256)).to.equal(true);
+
+    // When checking that MUSDC is supported on the bridge
+    // Then the token should be supported
+    expect(await bridgeContract.supportedTokens(musdcAddress)).to.equal(true);
+    const musdcSupportedTokenInfo = await bridgeContract.tokenAllowances(musdcAddress);
+
+    // And the token should have the expected reset time
+    expect(musdcSupportedTokenInfo[0].eq(expectedTimeStamp)).to.equal(true);
+
+    // And the token should have the expected daily allowance
+    expect(musdcSupportedTokenInfo[1].eq(ethers.constants.MaxInt256)).to.equal(true);
+
+    // When checking that bridgeToDeFiChain can be called with a MUSDT token
+    // And provisioning the necessary approval
+    await musdtContract.approve(bridgeProxyAddress, ethers.constants.MaxInt256);
+
+    // Then the call should not revert
+    await bridgeContract.bridgeToDeFiChain(ethers.constants.AddressZero, musdtAddress, 1);
+
+    // And the EOA's balance of MUSDT should be reduced by 1
+    expect((await musdtContract.balanceOf(eoaAddress)).eq(999_999_999)).to.eq(true);
+
+    // When checking that bridgeToDeFiChain can be called with a MUSDC token
+    // And provisioning the necessary approval
+    await musdcContract.approve(bridgeProxyAddress, ethers.constants.MaxInt256);
+
+    // Then the call should not revert
+    await bridgeContract.bridgeToDeFiChain(ethers.constants.AddressZero, musdcAddress, 1);
+
+    // And the EOA's balance of MUSDT should be reduced by 1
+    expect((await musdcContract.balanceOf(eoaAddress)).eq(999_999_999)).to.eq(true);
+  });
+});


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
As per title. The README describes what to do with this, copying it here:

---
## Setting up local environment

This section outlines how to get started on integrating with the smart contracts for the Bridge on your dApp.
There are many different ways, but this is the simplest and fastest method.

1. In your terminal, run `npx hardhat --config ./src/hardhat.config.ts node` from this package's directory
   - This runs a new Hardhat node locally, listening on `http://127.0.0.1:8545`
2. In another terminal, run `npx hardhat --config ./src/hardhat.config.ts --network localhost setupLocalTestnet`
   - This will deploy the smart contracts to the local Hardhat node that you have started
   - This command will also log out the different contract addresses, and the minted tokens

You're done! Your dApp can now interact with the smart contracts on the local Hardhat node.
---

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Should improve the devx a lot of UI devs

