### PR TITLE
feat(PostgreSQL & EVMTransactionConfirmer service rework): Created a Prisma Service that is made available to be injected globally, and reworked EVMTransactionConfirmer service logic to use this PostgreSQL service

### DIFF
--- a/apps/server/.env
+++ b/apps/server/.env
@@ -1,6 +1,6 @@
 # Environment variables declared in this file are automatically made available in server.
 
-POSTGRES_DB="bridge"
-POSTGRES_USER="playground"
-POSTGRES_PASSWORD="playground"
+POSTGRES_DB="bridge-db"
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="password"
 DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}?schema=public"

--- a/apps/server/src/AppConfig.ts
+++ b/apps/server/src/AppConfig.ts
@@ -1,7 +1,10 @@
 import * as Joi from 'joi';
 
+export const DATABASE_URL = 'DATABASE_URL';
+
 export function appConfig() {
   return {
+    [DATABASE_URL]: process.env[DATABASE_URL],
     defichain: {
       mainnet: process.env.DEFICHAIN_MAINNET_KEY,
       regtest:
@@ -31,4 +34,5 @@ export const ENV_VALIDATION_SCHEMA = Joi.object({
   ETHEREUM_RPC_URL: Joi.string().ip(),
   DEFICHAIN_MAINNET_KEY: Joi.string(),
   DEFICHAIN_REGTEST_KEY: Joi.string(),
+  [DATABASE_URL]: Joi.string().required(),
 });

--- a/apps/server/src/AppConfig.ts
+++ b/apps/server/src/AppConfig.ts
@@ -12,10 +12,28 @@ export function appConfig() {
       rpcUrl: process.env.ETHEREUM_RPC_URL || 'localhost:8545',
     },
     contract: {
-      address: process.env.BRIDGE_CONTRACT_ADDRESS || '',
+      bridgeProxy: {
+        mainnetAddress: undefined,
+        testnetAddress: '0x93fE70235854e7c97A5db5ddfC6eAAb078e99d3C',
+      },
     },
   };
 }
+export type AppConfig = {
+  defichain?: {
+    mainnet?: string;
+    regtest?: string;
+  };
+  ethereum?: {
+    rpcUrl?: string;
+  };
+  contract?: {
+    bridgeProxy?: {
+      mainnetAddress?: string;
+      testnetAddress?: string;
+    };
+  };
+};
 
 export const ENV_VALIDATION_SCHEMA = Joi.object({
   ETHEREUM_RPC_URL: Joi.string().ip(),

--- a/apps/server/src/AppConfig.ts
+++ b/apps/server/src/AppConfig.ts
@@ -11,6 +11,9 @@ export function appConfig() {
     ethereum: {
       rpcUrl: process.env.ETHEREUM_RPC_URL || 'localhost:8545',
     },
+    contract: {
+      address: process.env.BRIDGE_CONTRACT_ADDRESS || '',
+    },
   };
 }
 

--- a/apps/server/src/AppConfig.ts
+++ b/apps/server/src/AppConfig.ts
@@ -20,9 +20,11 @@ export function appConfig() {
   };
 }
 
-type DeepPartial<T> = {
-  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
-};
+type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;
 export type AppConfig = DeepPartial<ReturnType<typeof appConfig>>;
 
 export const ENV_VALIDATION_SCHEMA = Joi.object({

--- a/apps/server/src/AppConfig.ts
+++ b/apps/server/src/AppConfig.ts
@@ -19,21 +19,11 @@ export function appConfig() {
     },
   };
 }
-export type AppConfig = {
-  defichain?: {
-    mainnet?: string;
-    regtest?: string;
-  };
-  ethereum?: {
-    rpcUrl?: string;
-  };
-  contract?: {
-    bridgeProxy?: {
-      mainnetAddress?: string;
-      testnetAddress?: string;
-    };
-  };
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
 };
+export type AppConfig = DeepPartial<ReturnType<typeof appConfig>>;
 
 export const ENV_VALIDATION_SCHEMA = Joi.object({
   ETHEREUM_RPC_URL: Joi.string().ip(),

--- a/apps/server/src/AppController.ts
+++ b/apps/server/src/AppController.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Body, Controller, Get, ParseIntPipe,Post, Query } from '@nestjs/common';
 import { BigNumber } from 'ethers';
 
 import { AppService } from './AppService';
@@ -16,4 +16,16 @@ export class AppController {
   async getBalance(@Query('address') address: string): Promise<BigNumber> {
     return this.appService.getBalance(address);
   }
+
+  @Post('getAllEventsFromBlockNumber')
+  async getAllEventsFromBlockNumber(
+    @Body('blockNumber', ParseIntPipe) blockNumber: number,
+    @Body('contractAddress') contractAddress: string,
+  ): Promise<object[]> {
+    return this.appService.getAllEventsFromBlockNumber(blockNumber, contractAddress);
+  }
+  // @Get('getAllEventsFromBlockNumber')
+  // async getAllEventsFromBlockNumber(@Query('blockNumber') blockNumber:number): Promise<object[]>{
+  //   return this.appService.getAllEventsFromBlockNumber(Number(blockNumber))
+  // }
 }

--- a/apps/server/src/AppController.ts
+++ b/apps/server/src/AppController.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Post, Query } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { BigNumber, Event } from 'ethers';
 
 import { AppService } from './AppService';
@@ -18,7 +19,17 @@ export class AppController {
   }
 
   @Get('getAllEventsFromBlockNumber')
-  async getAllEventsFromBlockNumber(@Query('blockNumber') blockNumber: number): Promise<Event[]> {
-    return this.appService.getAllEventsFromBlockNumber(Number(blockNumber));
+  async getAllEventsFromBlockNumber(): Promise<Event[]> {
+    return this.appService.getAllEventsFromBlockNumber();
+  }
+
+  @Post('initDatabase')
+  async initDatabase(@Body() body: Prisma.blockNumberCreateManyInput): Promise<Prisma.BatchPayload> {
+    return this.appService.initDatabase(body);
+  }
+
+  @Delete('initDatabase')
+  async deleteDatabase(): Promise<Prisma.BatchPayload> {
+    return this.appService.deleteDatabase();
   }
 }

--- a/apps/server/src/AppController.ts
+++ b/apps/server/src/AppController.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Query } from '@nestjs/common';
-import { BigNumber } from 'ethers';
+import { BigNumber, Event } from 'ethers';
 
 import { AppService } from './AppService';
 
@@ -18,7 +18,7 @@ export class AppController {
   }
 
   @Get('getAllEventsFromBlockNumber')
-  async getAllEventsFromBlockNumber(@Query('blockNumber') blockNumber: number): Promise<object[]> {
+  async getAllEventsFromBlockNumber(@Query('blockNumber') blockNumber: number): Promise<Event[]> {
     return this.appService.getAllEventsFromBlockNumber(Number(blockNumber));
   }
 }

--- a/apps/server/src/AppController.ts
+++ b/apps/server/src/AppController.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, ParseIntPipe,Post, Query } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { BigNumber } from 'ethers';
 
 import { AppService } from './AppService';
@@ -17,15 +17,8 @@ export class AppController {
     return this.appService.getBalance(address);
   }
 
-  @Post('getAllEventsFromBlockNumber')
-  async getAllEventsFromBlockNumber(
-    @Body('blockNumber', ParseIntPipe) blockNumber: number,
-    @Body('contractAddress') contractAddress: string,
-  ): Promise<object[]> {
-    return this.appService.getAllEventsFromBlockNumber(blockNumber, contractAddress);
+  @Get('getAllEventsFromBlockNumber')
+  async getAllEventsFromBlockNumber(@Query('blockNumber') blockNumber: number): Promise<object[]> {
+    return this.appService.getAllEventsFromBlockNumber(Number(blockNumber));
   }
-  // @Get('getAllEventsFromBlockNumber')
-  // async getAllEventsFromBlockNumber(@Query('blockNumber') blockNumber:number): Promise<object[]>{
-  //   return this.appService.getAllEventsFromBlockNumber(Number(blockNumber))
-  // }
 }

--- a/apps/server/src/AppModule.ts
+++ b/apps/server/src/AppModule.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_GUARD, RouterModule } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 
-import { appConfig, ENV_VALIDATION_SCHEMA } from './AppConfig';
+import { appConfig, DATABASE_URL, ENV_VALIDATION_SCHEMA } from './AppConfig';
 import { AppController } from './AppController';
 import { AppService } from './AppService';
 import { DeFiChainModule } from './defichain/DeFiChainModule';
 import { EthersModule } from './modules/EthersModule';
+import { PrismaService } from './PrismaService';
 
 @Module({
   imports: [
@@ -33,6 +34,12 @@ import { EthersModule } from './modules/EthersModule';
   providers: [
     AppService,
     DeFiChainModule,
+    PrismaService,
+    {
+      provide: DATABASE_URL,
+      useFactory: (cfg: ConfigService) => cfg.getOrThrow(DATABASE_URL),
+      inject: [ConfigService],
+    },
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,

--- a/apps/server/src/AppService.ts
+++ b/apps/server/src/AppService.ts
@@ -1,16 +1,24 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { BigNumber, ethers } from 'ethers';
+import { BigNumber, Contract, ethers, Event } from 'ethers';
 import { BridgeV1__factory } from 'smartcontracts';
 
 import { ETHERS_RPC_PROVIDER } from './modules/EthersModule';
 
 @Injectable()
 export class AppService {
+  private contract: Contract;
+
   constructor(
     @Inject(ETHERS_RPC_PROVIDER) readonly ethersRpcProvider: ethers.providers.StaticJsonRpcProvider,
     private configService: ConfigService,
-  ) {}
+  ) {
+    this.contract = new ethers.Contract(
+      this.configService.getOrThrow('contract.bridgeProxy.testnetAddress'),
+      BridgeV1__factory.abi,
+      this.ethersRpcProvider,
+    );
+  }
 
   async getBlockHeight(): Promise<number> {
     return this.ethersRpcProvider.getBlockNumber();
@@ -20,15 +28,9 @@ export class AppService {
     return this.ethersRpcProvider.getBalance(address);
   }
 
-  async getAllEventsFromBlockNumber(blockNumber: number): Promise<object[]> {
+  async getAllEventsFromBlockNumber(blockNumber: number): Promise<Event[]> {
     const currentBlockNumber = await this.ethersRpcProvider.getBlockNumber();
-    const contract = new ethers.Contract(
-      this.configService.getOrThrow('contract.address'),
-      BridgeV1__factory.abi,
-      this.ethersRpcProvider,
-    );
-    const eventSignature = contract.filters.BRIDGE_TO_DEFI_CHAIN();
-    const events = await contract.queryFilter(eventSignature, blockNumber, currentBlockNumber - 65);
-    return events;
+    const eventSignature = this.contract.filters.BRIDGE_TO_DEFI_CHAIN();
+    return this.contract.queryFilter(eventSignature, blockNumber, currentBlockNumber - 65);
   }
 }

--- a/apps/server/src/AppService.ts
+++ b/apps/server/src/AppService.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { BigNumber, ethers } from 'ethers';
+import { BridgeV1__factory } from 'smartcontracts';
 
 import { ETHERS_RPC_PROVIDER } from './modules/EthersModule';
 
@@ -13,5 +14,13 @@ export class AppService {
 
   async getBalance(address: string): Promise<BigNumber> {
     return this.ethersRpcProvider.getBalance(address);
+  }
+
+  async getAllEventsFromBlockNumber(blockNumber: number, contractAddress: string): Promise<object[]> {
+    const currentBlockNumber = await this.ethersRpcProvider.getBlockNumber();
+    const contract = new ethers.Contract(contractAddress, BridgeV1__factory.abi, this.ethersRpcProvider);
+    const eventSignature = contract.filters.BRIDGE_TO_DEFI_CHAIN();
+    const events = await contract.queryFilter(eventSignature, blockNumber, currentBlockNumber - 65);
+    return events;
   }
 }

--- a/apps/server/src/PrismaService.ts
+++ b/apps/server/src/PrismaService.ts
@@ -1,0 +1,21 @@
+import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+import { DATABASE_URL } from './AppConfig';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  constructor(@Inject(DATABASE_URL) private readonly dbUrl: string) {
+    super({
+      datasources: {
+        db: {
+          url: dbUrl,
+        },
+      },
+    });
+  }
+
+  async onModuleInit(): Promise<void> {
+    await this.$connect();
+  }
+}

--- a/apps/server/test-i9n/BridgeApp.i9n.ts
+++ b/apps/server/test-i9n/BridgeApp.i9n.ts
@@ -177,10 +177,10 @@ describe('Bridge Service Integration Tests', () => {
     );
     await hardhatNetwork.generate(1);
 
-    // Step 10: generate 30 blocks (block 1106)
+    // Step 10: generate 30 blocks (block 1101)
     await hardhatNetwork.generate(30);
 
-    // step 11: current block should be block 1106
+    // step 11: current block should be block 1101
     currBlock = await testing.inject({
       method: 'GET',
       url: '/app/blockheight',
@@ -236,7 +236,7 @@ describe('Bridge Service Integration Tests', () => {
   });
 
   it('should be able to make calls to the underlying hardhat node', async () => {
-    // Given an initial block height of 1106 (due to the initial block generation when calling HardhatNetwork.ready())
+    // Given an initial block height of 1136 (due to the initial block generation when calling HardhatNetwork.ready())
     const initialResponse = await testing.inject({
       method: 'GET',
       url: '/app/blockheight',

--- a/apps/server/test-i9n/BridgeApp.i9n.ts
+++ b/apps/server/test-i9n/BridgeApp.i9n.ts
@@ -26,17 +26,29 @@ export class TestingExampleModule {
   }
 }
 
-export function buildTestConfig(startedHardhatContainer: StartedHardhatNetworkContainer, contractAddress?: string) {
-  return {
-    ethereum: {
-      rpcUrl: startedHardhatContainer.rpcUrl,
-    },
-    contract: {
-      bridgeProxy: {
-        testnetAddress: contractAddress,
-      },
-    },
-  };
+export function buildTestConfig({
+  startedHardhatContainer,
+  contractAddress,
+}: {
+  startedHardhatContainer: StartedHardhatNetworkContainer;
+  contractAddress?: string;
+}) {
+  return contractAddress
+    ? {
+        ethereum: {
+          rpcUrl: startedHardhatContainer.rpcUrl,
+        },
+        contract: {
+          bridgeProxy: {
+            testnetAddress: contractAddress,
+          },
+        },
+      }
+    : {
+        ethereum: {
+          rpcUrl: startedHardhatContainer.rpcUrl,
+        },
+      };
 }
 
 describe('Bridge Service Integration Tests', () => {
@@ -93,7 +105,9 @@ describe('Bridge Service Integration Tests', () => {
 
     // initialize config variables
     testing = new BridgeServerTestingApp(
-      TestingExampleModule.register(buildTestConfig(startedHardhatContainer, bridgeUpgradeable.address)),
+      TestingExampleModule.register(
+        buildTestConfig({ startedHardhatContainer, contractAddress: bridgeUpgradeable.address }),
+      ),
     );
     await testing.start();
   });

--- a/apps/server/test-i9n/BridgeApp.i9n.ts
+++ b/apps/server/test-i9n/BridgeApp.i9n.ts
@@ -187,7 +187,7 @@ describe('Bridge Service Integration Tests', () => {
     });
     await expect(currBlock.body).toStrictEqual('1101');
 
-    // Step 12: getAllEventsFromBlockNumber?blockNumber=1005 should return array of events of length 1
+    // Step 12: getAllEventsFromBlockNumber where blockNumber=1005 should return array of events of length 1
     eventsArray = await testing.inject({
       method: 'POST',
       url: `/app/getAllEventsFromBlockNumber`,
@@ -201,7 +201,7 @@ describe('Bridge Service Integration Tests', () => {
     // Step 13: Generate another 35 blocks to achieve confirmation for second event
     await hardhatNetwork.generate(35);
 
-    // Step 14: getAllEventsFromBlockNumber?blockNumber=1005 should return array of events of length 2 now
+    // Step 14: getAllEventsFromBlockNumber where blockNumber=1005 should return array of events of length 2 now
     eventsArray = await testing.inject({
       method: 'POST',
       url: `/app/getAllEventsFromBlockNumber`,
@@ -212,7 +212,7 @@ describe('Bridge Service Integration Tests', () => {
     });
     await expect(JSON.parse(eventsArray.body)).toHaveLength(2);
 
-    // Step 15: getAllEventsFromBlockNumber?blockNumber=1071 should return array of events of length 1
+    // Step 15: getAllEventsFromBlockNumber where blockNumber=1071 should return array of events of length 1
     eventsArray = await testing.inject({
       method: 'POST',
       url: `/app/getAllEventsFromBlockNumber`,
@@ -223,7 +223,7 @@ describe('Bridge Service Integration Tests', () => {
     });
     await expect(JSON.parse(eventsArray.body)).toHaveLength(1);
 
-    // Step 16: getAllEventsFromBlockNumber?blockNumber=1072 should return array of events of length 0
+    // Step 16: getAllEventsFromBlockNumber where blockNumber=1072 should return array of events of length 0
     eventsArray = await testing.inject({
       method: 'POST',
       url: `/app/getAllEventsFromBlockNumber`,
@@ -236,7 +236,7 @@ describe('Bridge Service Integration Tests', () => {
   });
 
   it('should be able to make calls to the underlying hardhat node', async () => {
-    // Given an initial block height of 1136 (due to the initial block generation when calling HardhatNetwork.ready())
+    // Given an initial block height of 1136 (due to the initial block generation when calling HardhatNetwork.ready() + getAllEventsFromBlockNumber tests)
     const initialResponse = await testing.inject({
       method: 'GET',
       url: '/app/blockheight',

--- a/apps/server/test-i9n/BridgeApp.i9n.ts
+++ b/apps/server/test-i9n/BridgeApp.i9n.ts
@@ -1,6 +1,16 @@
 import { DynamicModule, Module } from '@nestjs/common';
 import { ConfigModule, registerAs } from '@nestjs/config';
-import { HardhatNetwork, HardhatNetworkContainer, StartedHardhatNetworkContainer } from 'smartcontracts';
+import { ethers } from 'ethers';
+import {
+  BridgeProxy,
+  BridgeProxy__factory,
+  BridgeV1,
+  BridgeV1__factory,
+  EvmContractManager,
+  HardhatNetwork,
+  HardhatNetworkContainer,
+  StartedHardhatNetworkContainer,
+} from 'smartcontracts';
 
 import { AppModule } from '../src/AppModule';
 import { BridgeServerTestingApp } from '../src/BridgeServerTestingApp';
@@ -22,11 +32,55 @@ export class TestingExampleModule {
 describe('Bridge Service Integration Tests', () => {
   let startedHardhatContainer: StartedHardhatNetworkContainer;
   let hardhatNetwork: HardhatNetwork;
+  let evmContractManager: EvmContractManager;
+  let defaultAdminAddress: string;
+  let defaultAdminSigner: ethers.Signer;
+  let operationalAdminAddress: string;
+  let bridgeUpgradeable: BridgeV1;
+  let bridgeProxy: BridgeProxy;
   let testing: BridgeServerTestingApp;
 
   beforeAll(async () => {
     startedHardhatContainer = await new HardhatNetworkContainer().start();
     hardhatNetwork = await startedHardhatContainer.ready();
+
+    evmContractManager = hardhatNetwork.contracts;
+    // Default and operational admin account
+    ({ testWalletAddress: defaultAdminAddress, testWalletSigner: defaultAdminSigner } =
+      await hardhatNetwork.createTestWallet());
+    ({ testWalletAddress: operationalAdminAddress } = await hardhatNetwork.createTestWallet());
+
+    // Deploying BridgeV1 contract
+    bridgeUpgradeable = await evmContractManager.deployContract<BridgeV1>({
+      deploymentName: 'BridgeV1',
+      contractName: 'BridgeV1',
+      abi: BridgeV1__factory.abi,
+    });
+    await hardhatNetwork.generate(1);
+
+    // Deployment arguments for the Proxy contract
+    const encodedData = BridgeV1__factory.createInterface().encodeFunctionData('initialize', [
+      'CAKE_BRIDGE',
+      '0.1',
+      defaultAdminAddress,
+      operationalAdminAddress,
+      defaultAdminAddress,
+      30, // 0.3% txn fee
+    ]);
+
+    // Deploying proxy contract
+    bridgeProxy = await evmContractManager.deployContract<BridgeProxy>({
+      deploymentName: 'BridgeProxy',
+      contractName: 'BridgeProxy',
+      deployArgs: [bridgeUpgradeable.address, encodedData],
+      abi: BridgeProxy__factory.abi,
+    });
+    await hardhatNetwork.generate(1);
+
+    // Attach proxy address to bridgeUpgradeable contract
+    bridgeUpgradeable = bridgeUpgradeable.attach(bridgeProxy.address);
+    await hardhatNetwork.generate(1);
+
     testing = new BridgeServerTestingApp(TestingExampleModule.register(startedHardhatContainer));
     await testing.start();
   });
@@ -35,14 +89,160 @@ describe('Bridge Service Integration Tests', () => {
     await hardhatNetwork.stop();
   });
 
+  describe('Proxy contract deployment', () => {
+    it("Contract code should not be equal to '0x'", async () => {
+      await expect(hardhatNetwork.ethersRpcProvider.getCode(bridgeUpgradeable.address)).resolves.not.toStrictEqual(
+        '0x',
+      );
+    });
+    it('Admin address should be Default Admin address', async () => {
+      const DEFAULT_ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000';
+      expect(await bridgeUpgradeable.hasRole(DEFAULT_ADMIN_ROLE, defaultAdminAddress)).toBe(true);
+    });
+    it('Operational address should be Operational Admin address', async () => {
+      const OPERATIONAL_ROLE = ethers.utils.solidityKeccak256(['string'], ['OPERATIONAL_ROLE']);
+      expect(await bridgeUpgradeable.hasRole(OPERATIONAL_ROLE, operationalAdminAddress)).toBe(true);
+    });
+    it('Relayer address should be Default Admin address', async () => {
+      expect(await bridgeUpgradeable.relayerAddress()).toBe(defaultAdminAddress);
+    });
+    it('Successfully implemented the 0.3% txn fee', async () => {
+      expect((await bridgeUpgradeable.transactionFee()).toString()).toBe('30');
+    });
+  });
+
+  it('Returns an array of confirmed events from a given block number', async () => {
+    // Step 1: starting block should be 1003 (after initializations)
+    let currBlock = await testing.inject({
+      method: 'GET',
+      url: '/app/blockheight',
+    });
+    await expect(currBlock.body).toStrictEqual('1003');
+
+    // Step 2: Call addSupportedTokens function and mine the block (block 1004)
+    await bridgeUpgradeable
+      .connect(defaultAdminSigner)
+      .addSupportedTokens(ethers.constants.AddressZero, ethers.utils.parseEther('10'), Math.floor(Date.now() / 1000));
+    await hardhatNetwork.generate(1);
+
+    // Step 3: Call bridgeToDeFiChain(_defiAddress, _tokenAddress, _amount) function and mine the block (block 1005)
+    await bridgeUpgradeable.bridgeToDeFiChain(
+      ethers.constants.AddressZero,
+      ethers.constants.AddressZero,
+      ethers.utils.parseEther('5'),
+      {
+        value: ethers.utils.parseEther('3'),
+      },
+    );
+    await hardhatNetwork.generate(1);
+
+    // step 4: currBlock should now be 1005
+    currBlock = await testing.inject({
+      method: 'GET',
+      url: '/app/blockheight',
+    });
+    await expect(currBlock.body).toStrictEqual('1005');
+
+    // step 5: calling my service should return a empty array (because it is not confirmed)
+    const payload = {
+      blockNumber: 1000,
+      contractAddress: bridgeUpgradeable.address,
+    };
+    let eventsArray = await testing.inject({
+      method: 'POST',
+      url: `/app/getAllEventsFromBlockNumber`,
+      payload,
+    });
+    await expect(JSON.parse(eventsArray.body)).toHaveLength(0);
+
+    // step 6: generate 65 blocks (to simulate confirmation)
+    await hardhatNetwork.generate(65);
+
+    // step 7: calling my service should return a array of length 1
+    eventsArray = await testing.inject({
+      method: 'POST',
+      url: `/app/getAllEventsFromBlockNumber`,
+      payload,
+    });
+    await expect(JSON.parse(eventsArray.body)).toHaveLength(1);
+
+    // Step 8: Call bridgeToDeFiChain(_defiAddress, _tokenAddress, _amount) a second time and mine it (block 1071)
+    await bridgeUpgradeable.bridgeToDeFiChain(
+      ethers.constants.AddressZero,
+      ethers.constants.AddressZero,
+      ethers.utils.parseEther('5'),
+      {
+        value: ethers.utils.parseEther('3'),
+      },
+    );
+    await hardhatNetwork.generate(1);
+
+    // Step 10: generate 30 blocks (block 1106)
+    await hardhatNetwork.generate(30);
+
+    // step 11: current block should be block 1106
+    currBlock = await testing.inject({
+      method: 'GET',
+      url: '/app/blockheight',
+    });
+    await expect(currBlock.body).toStrictEqual('1101');
+
+    // Step 12: getAllEventsFromBlockNumber?blockNumber=1005 should return array of events of length 1
+    eventsArray = await testing.inject({
+      method: 'POST',
+      url: `/app/getAllEventsFromBlockNumber`,
+      payload: {
+        blockNumber: 1005,
+        contractAddress: bridgeUpgradeable.address,
+      },
+    });
+    await expect(JSON.parse(eventsArray.body)).toHaveLength(1);
+
+    // Step 13: Generate another 35 blocks to achieve confirmation for second event
+    await hardhatNetwork.generate(35);
+
+    // Step 14: getAllEventsFromBlockNumber?blockNumber=1005 should return array of events of length 2 now
+    eventsArray = await testing.inject({
+      method: 'POST',
+      url: `/app/getAllEventsFromBlockNumber`,
+      payload: {
+        blockNumber: 1005,
+        contractAddress: bridgeUpgradeable.address,
+      },
+    });
+    await expect(JSON.parse(eventsArray.body)).toHaveLength(2);
+
+    // Step 15: getAllEventsFromBlockNumber?blockNumber=1071 should return array of events of length 1
+    eventsArray = await testing.inject({
+      method: 'POST',
+      url: `/app/getAllEventsFromBlockNumber`,
+      payload: {
+        blockNumber: 1071,
+        contractAddress: bridgeUpgradeable.address,
+      },
+    });
+    await expect(JSON.parse(eventsArray.body)).toHaveLength(1);
+
+    // Step 16: getAllEventsFromBlockNumber?blockNumber=1072 should return array of events of length 0
+    eventsArray = await testing.inject({
+      method: 'POST',
+      url: `/app/getAllEventsFromBlockNumber`,
+      payload: {
+        blockNumber: 1072,
+        contractAddress: bridgeUpgradeable.address,
+      },
+    });
+    await expect(JSON.parse(eventsArray.body)).toHaveLength(0);
+  });
+
   it('should be able to make calls to the underlying hardhat node', async () => {
-    // Given an initial block height of 1000 (due to the initial block generation when calling HardhatNetwork.ready())
+    // Given an initial block height of 1106 (due to the initial block generation when calling HardhatNetwork.ready())
     const initialResponse = await testing.inject({
       method: 'GET',
       url: '/app/blockheight',
     });
 
-    await expect(initialResponse.body).toStrictEqual('1000');
+    await expect(initialResponse.body).toStrictEqual('1136');
 
     // When one block is mined
     await hardhatNetwork.generate(1);
@@ -53,6 +253,6 @@ describe('Bridge Service Integration Tests', () => {
       url: '/app/blockheight',
     });
 
-    expect(responseAfterGenerating.body).toStrictEqual('1001');
+    expect(responseAfterGenerating.body).toStrictEqual('1137');
   });
 });

--- a/apps/server/test-i9n/defichain/stats.i9n.ts
+++ b/apps/server/test-i9n/defichain/stats.i9n.ts
@@ -11,7 +11,7 @@ describe('DeFiChain Wallet Integration Testing', () => {
   beforeAll(async () => {
     startedHardhatContainer = await new HardhatNetworkContainer().start();
     hardhatNetwork = await startedHardhatContainer.ready();
-    testing = new BridgeServerTestingApp(TestingExampleModule.register(buildTestConfig(startedHardhatContainer, '')));
+    testing = new BridgeServerTestingApp(TestingExampleModule.register(buildTestConfig({ startedHardhatContainer })));
     await testing.start();
   });
 

--- a/apps/server/test-i9n/defichain/stats.i9n.ts
+++ b/apps/server/test-i9n/defichain/stats.i9n.ts
@@ -1,7 +1,7 @@
 import { HardhatNetwork, HardhatNetworkContainer, StartedHardhatNetworkContainer } from 'smartcontracts';
 
 import { BridgeServerTestingApp } from '../../src/BridgeServerTestingApp';
-import { TestingExampleModule } from '../BridgeApp.i9n';
+import { buildTestConfig, TestingExampleModule } from '../BridgeApp.i9n';
 
 describe('DeFiChain Wallet Integration Testing', () => {
   let startedHardhatContainer: StartedHardhatNetworkContainer;
@@ -11,7 +11,7 @@ describe('DeFiChain Wallet Integration Testing', () => {
   beforeAll(async () => {
     startedHardhatContainer = await new HardhatNetworkContainer().start();
     hardhatNetwork = await startedHardhatContainer.ready();
-    testing = new BridgeServerTestingApp(TestingExampleModule.register(startedHardhatContainer));
+    testing = new BridgeServerTestingApp(TestingExampleModule.register(buildTestConfig(startedHardhatContainer, '')));
     await testing.start();
   });
 

--- a/apps/server/test-i9n/defichain/wallet.i9n.ts
+++ b/apps/server/test-i9n/defichain/wallet.i9n.ts
@@ -2,7 +2,7 @@ import { fromAddress } from '@defichain/jellyfish-address';
 import { HardhatNetwork, HardhatNetworkContainer, StartedHardhatNetworkContainer } from 'smartcontracts';
 
 import { BridgeServerTestingApp } from '../../src/BridgeServerTestingApp';
-import { TestingExampleModule } from '../BridgeApp.i9n';
+import { buildTestConfig, TestingExampleModule } from '../BridgeApp.i9n';
 
 describe('DeFiChain Wallet Integration Testing', () => {
   let startedHardhatContainer: StartedHardhatNetworkContainer;
@@ -13,7 +13,7 @@ describe('DeFiChain Wallet Integration Testing', () => {
   beforeAll(async () => {
     startedHardhatContainer = await new HardhatNetworkContainer().start();
     hardhatNetwork = await startedHardhatContainer.ready();
-    testing = new BridgeServerTestingApp(TestingExampleModule.register(startedHardhatContainer));
+    testing = new BridgeServerTestingApp(TestingExampleModule.register(buildTestConfig(startedHardhatContainer, '')));
     await testing.start();
   });
 

--- a/apps/server/test-i9n/defichain/wallet.i9n.ts
+++ b/apps/server/test-i9n/defichain/wallet.i9n.ts
@@ -13,7 +13,7 @@ describe('DeFiChain Wallet Integration Testing', () => {
   beforeAll(async () => {
     startedHardhatContainer = await new HardhatNetworkContainer().start();
     hardhatNetwork = await startedHardhatContainer.ready();
-    testing = new BridgeServerTestingApp(TestingExampleModule.register(buildTestConfig(startedHardhatContainer, '')));
+    testing = new BridgeServerTestingApp(TestingExampleModule.register(buildTestConfig({ startedHardhatContainer })));
     await testing.start();
   });
 

--- a/apps/server/with-db
+++ b/apps/server/with-db
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+C='\033[1;36m' # Highlight - light cyan
+P='\033[1;35m' # Highlight - light purple
+N='\033[0m' # No color
+log() {
+  echo "${C}[$(date +"%F %T %Z")] ${P}$1${N}"
+}
+
+# Takes care of spinning up a local db container and waiting for it to be ready
+# prior to any prisma command that requires a database connection.
+# E.g. `prisma migrate dev` for creating migrations after making schema changes.
+log "Spinning up local database..."
+
+# Start local dev db container with dev credentials
+POSTGRES_IMAGE=postgres:14.5
+POSTGRES_PORT=5432
+POSTGRES_DATABASE=bridge-db
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+
+docker pull $POSTGRES_IMAGE
+docker start bridge-db || docker run -p $POSTGRES_PORT:$POSTGRES_PORT -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -e POSTGRES_DATABASE=$POSTGRES_DATABASE -d --name $POSTGRES_DATABASE $POSTGRES_IMAGE
+printf "\n"
+
+# Wait for container to be ready
+until [ "$(docker inspect -f {{.State.Running}} bridge-db)" = "true" ]; do
+  log "Waiting for container to run..."
+  sleep 0.3;
+done;
+
+# Execute an arbitrary query to ensure db is ready
+until [[ $(docker exec bridge-db psql -U postgres -c "SELECT 'ready'" | grep ready) == *"ready"* ]]; do
+  log "Waiting for database to be ready..."
+  sleep 0.3;
+done;
+
+# Register env variable for prisma to connect to db
+export DATABASE_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:$POSTGRES_PORT/$POSTGRES_DATABASE
+log "Database started - connection url: $DATABASE_URL"
+
+# Run prisma command
+npx prisma "$@"
+log "Finished!"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

1. Created a with-db bash script to take care of spinning up a local db container and waiting for it to be ready prior to any prisma command that requires a database connection.

To spin up the docker container before running tests:
- In terminal (/bridge), run `cd apps/server`
- Run `./with-db generate`
- Run `./with-db migrate dev`
- Run`pnpm run test` to run reworked integration test

2. Created a Prisma Service that is made available to be injected globally

3. Reworked EVMTransactionConfirmer service logic to use this PostgreSQL service to track the block number of the last checked block. It uses the local PostgreSQL database record's block number to check for events emitted from **last checked block number** to **current block number - 65**

- If current block number -64 > last checked block number, store **last checked block number = current block number -64**


#### Which issue(s) does this PR fixes?:
281
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] Unit tests\*
- [x] Added e2e tests\*

<!--
* If applicable
-->
