### PR TITLE
feat(server): add health check service for database

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -44,6 +44,7 @@
     "@nestjs/config": "^2.3.1",
     "@nestjs/core": "^9.3.8",
     "@nestjs/platform-fastify": "^9.3.8",
+    "@nestjs/terminus": "^9.2.0",
     "@nestjs/throttler": "^3.1.0",
     "@prisma/client": "^4.10.1",
     "@waveshq/walletkit-core": "^0.37.0",

--- a/apps/server/src/AppModule.ts
+++ b/apps/server/src/AppModule.ts
@@ -7,6 +7,7 @@ import { appConfig, ENV_VALIDATION_SCHEMA } from './AppConfig';
 import { DeFiChainModule } from './defichain/DeFiChainModule';
 import { EthereumModule } from './ethereum/EthereumModule';
 import { EthersModule } from './modules/EthersModule';
+import { HealthModule } from './modules/HealthModule';
 import { PrismaService } from './PrismaService';
 
 @Module({
@@ -33,6 +34,7 @@ import { PrismaService } from './PrismaService';
         module: EthereumModule,
       },
     ]),
+    HealthModule,
   ],
   controllers: [],
   providers: [

--- a/apps/server/src/HealthController.ts
+++ b/apps/server/src/HealthController.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { HealthCheck,HealthCheckService } from '@nestjs/terminus';
+
+import { PrismaHealthIndicator } from './health/PrismaHealth';
+
+@Controller('health')
+export class HealthController {
+  constructor(private health: HealthCheckService, private prisma: PrismaHealthIndicator) {}
+
+  @Get()
+  @HealthCheck()
+  check() {
+    return this.health.check([() => this.prisma.isHealthy('database')]);
+  }
+}

--- a/apps/server/src/health/PrismaHealth.ts
+++ b/apps/server/src/health/PrismaHealth.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { HealthCheckError, HealthIndicator, HealthIndicatorResult } from '@nestjs/terminus';
+
+import { PrismaService } from '../PrismaService';
+
+@Injectable()
+export class PrismaHealthIndicator extends HealthIndicator {
+  constructor(private readonly prismaService: PrismaService) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    try {
+      await this.prismaService.$queryRaw`SELECT 1`;
+      return this.getStatus(key, true);
+    } catch (e) {
+      throw new HealthCheckError('Prisma check failed', e);
+    }
+  }
+}

--- a/apps/server/src/health/PrismaHealth.ts
+++ b/apps/server/src/health/PrismaHealth.ts
@@ -10,11 +10,10 @@ export class PrismaHealthIndicator extends HealthIndicator {
   }
 
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
-    try {
-      await this.prismaService.$queryRaw`SELECT 1`;
-      return this.getStatus(key, true);
-    } catch (e) {
-      throw new HealthCheckError('Prisma check failed', e);
-    }
+    return this.prismaService.$queryRaw`SELECT 1`
+      .then(() => this.getStatus(key, true))
+      .catch((e) => {
+        throw new HealthCheckError(e.message, this.getStatus(key, false, e));
+      });
   }
 }

--- a/apps/server/src/modules/HealthModule.ts
+++ b/apps/server/src/modules/HealthModule.ts
@@ -1,0 +1,14 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+
+import { PrismaHealthIndicator } from '../health/PrismaHealth';
+import { HealthController } from '../HealthController';
+import { PrismaService } from '../PrismaService';
+
+@Module({
+  imports: [TerminusModule, HttpModule],
+  controllers: [HealthController],
+  providers: [PrismaService, PrismaHealthIndicator],
+})
+export class HealthModule {}

--- a/apps/server/src/modules/HealthModule.ts
+++ b/apps/server/src/modules/HealthModule.ts
@@ -1,4 +1,3 @@
-import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 
@@ -7,7 +6,7 @@ import { HealthController } from '../HealthController';
 import { PrismaService } from '../PrismaService';
 
 @Module({
-  imports: [TerminusModule, HttpModule],
+  imports: [TerminusModule],
   controllers: [HealthController],
   providers: [PrismaService, PrismaHealthIndicator],
 })

--- a/apps/server/test-i9n/ethereum/transactionConfirmer.i9n.ts
+++ b/apps/server/test-i9n/ethereum/transactionConfirmer.i9n.ts
@@ -120,4 +120,25 @@ describe('Bridge Service Integration Tests', () => {
     });
     expect(transactionDbRecord?.status).toStrictEqual('CONFIRMED');
   });
+
+  it('Health check service should be ok', async () => {
+    const txReceipt = await testing.inject({
+      method: 'GET',
+      url: `/health`,
+    });
+    expect(JSON.parse(txReceipt.payload).status).toStrictEqual('ok');
+  });
+
+  it('Health check service should be error when database is down', async () => {
+    // mock error on Prisma query
+    jest.spyOn(prismaService, '$queryRaw').mockRejectedValue(new Error('Database Error!'));
+
+    const txReceipt = await testing.inject({
+      method: 'GET',
+      url: `/health`,
+    });
+
+    expect(JSON.parse(txReceipt.payload).status).toStrictEqual('error');
+    expect(JSON.parse(txReceipt.payload).error.database.status).toStrictEqual('down');
+  });
 });

--- a/apps/server/test-i9n/ethereum/transactionConfirmer.i9n.ts
+++ b/apps/server/test-i9n/ethereum/transactionConfirmer.i9n.ts
@@ -120,25 +120,4 @@ describe('Bridge Service Integration Tests', () => {
     });
     expect(transactionDbRecord?.status).toStrictEqual('CONFIRMED');
   });
-
-  it('Health check service should be ok', async () => {
-    const txReceipt = await testing.inject({
-      method: 'GET',
-      url: `/health`,
-    });
-    expect(JSON.parse(txReceipt.payload).status).toStrictEqual('ok');
-  });
-
-  it('Health check service should be error when database is down', async () => {
-    // mock error on Prisma query
-    jest.spyOn(prismaService, '$queryRaw').mockRejectedValue(new Error('Database Error!'));
-
-    const txReceipt = await testing.inject({
-      method: 'GET',
-      url: `/health`,
-    });
-
-    expect(JSON.parse(txReceipt.payload).status).toStrictEqual('error');
-    expect(JSON.parse(txReceipt.payload).error.database.status).toStrictEqual('down');
-  });
 });

--- a/apps/server/test-i9n/testing/HealthService.i9n.ts
+++ b/apps/server/test-i9n/testing/HealthService.i9n.ts
@@ -1,13 +1,11 @@
 import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@birthdayresearch/sticky-testcontainers';
 
-import { PrismaService } from '../../src/PrismaService';
 import { BridgeServerTestingApp } from './BridgeServerTestingApp';
 import { buildTestConfig, TestingModule } from './TestingModule';
 
 describe('Health Service Test', () => {
   let testing: BridgeServerTestingApp;
   let startedPostgresContainer: StartedPostgreSqlContainer;
-  let prismaService: PrismaService;
 
   beforeAll(async () => {
     startedPostgresContainer = await new PostgreSqlContainer().start();
@@ -20,8 +18,7 @@ describe('Health Service Test', () => {
       ),
     );
 
-    const app = await testing.start();
-    prismaService = app.get<PrismaService>(PrismaService);
+    await testing.start();
   });
 
   afterAll(async () => {
@@ -38,8 +35,7 @@ describe('Health Service Test', () => {
   });
 
   it('Health check service should be error when database is down', async () => {
-    // mock error on Prisma query
-    jest.spyOn(prismaService, '$queryRaw').mockRejectedValue(new Error('Database Error!'));
+    await startedPostgresContainer.stop();
 
     const txReceipt = await testing.inject({
       method: 'GET',

--- a/apps/server/test-i9n/testing/HealthService.i9n.ts
+++ b/apps/server/test-i9n/testing/HealthService.i9n.ts
@@ -1,0 +1,52 @@
+import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@birthdayresearch/sticky-testcontainers';
+
+import { PrismaService } from '../../src/PrismaService';
+import { BridgeServerTestingApp } from './BridgeServerTestingApp';
+import { buildTestConfig, TestingModule } from './TestingModule';
+
+describe('Health Service Test', () => {
+  let testing: BridgeServerTestingApp;
+  let startedPostgresContainer: StartedPostgreSqlContainer;
+  let prismaService: PrismaService;
+
+  beforeAll(async () => {
+    startedPostgresContainer = await new PostgreSqlContainer().start();
+
+    testing = new BridgeServerTestingApp(
+      TestingModule.register(
+        buildTestConfig({
+          startedPostgresContainer,
+        }),
+      ),
+    );
+
+    const app = await testing.start();
+    prismaService = app.get<PrismaService>(PrismaService);
+  });
+
+  afterAll(async () => {
+    await testing.stop();
+    await startedPostgresContainer.stop();
+  });
+
+  it('Health check service should be ok', async () => {
+    const txReceipt = await testing.inject({
+      method: 'GET',
+      url: `/health`,
+    });
+    expect(JSON.parse(txReceipt.payload).status).toStrictEqual('ok');
+  });
+
+  it('Health check service should be error when database is down', async () => {
+    // mock error on Prisma query
+    jest.spyOn(prismaService, '$queryRaw').mockRejectedValue(new Error('Database Error!'));
+
+    const txReceipt = await testing.inject({
+      method: 'GET',
+      url: `/health`,
+    });
+
+    expect(JSON.parse(txReceipt.payload).status).toStrictEqual('error');
+    expect(JSON.parse(txReceipt.payload).error.database.status).toStrictEqual('down');
+  });
+});

--- a/apps/server/test-i9n/testing/HealthService.i9n.ts
+++ b/apps/server/test-i9n/testing/HealthService.i9n.ts
@@ -1,23 +1,18 @@
 import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@birthdayresearch/sticky-testcontainers';
 
-import { DeFiChainStubContainer, StartedDeFiChainStubContainer } from '../defichain/containers/DeFiChainStubContainer';
 import { BridgeServerTestingApp } from './BridgeServerTestingApp';
 import { buildTestConfig, TestingModule } from './TestingModule';
 
 describe('Health Service Test', () => {
   let testing: BridgeServerTestingApp;
   let startedPostgresContainer: StartedPostgreSqlContainer;
-  let defichain: StartedDeFiChainStubContainer;
 
   beforeAll(async () => {
     startedPostgresContainer = await new PostgreSqlContainer().start();
 
-    defichain = await new DeFiChainStubContainer().start();
-    const whaleURL = await defichain.getWhaleURL();
     testing = new BridgeServerTestingApp(
       TestingModule.register(
         buildTestConfig({
-          defichain: { whaleURL, key: StartedDeFiChainStubContainer.LOCAL_MNEMONIC },
           startedPostgresContainer,
         }),
       ),
@@ -28,8 +23,6 @@ describe('Health Service Test', () => {
 
   afterAll(async () => {
     await testing.stop();
-    await startedPostgresContainer.stop();
-    await defichain.stop();
   });
 
   it('Health check service should be ok', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6040,6 +6040,12 @@ packages:
     dev: true
     optional: true
 
+  /ansi-align/3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+    dependencies:
+      string-width: 4.2.3
+    dev: false
+
   /ansi-colors/3.2.3:
     resolution: {integrity: sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==}
     engines: {node: '>=6'}
@@ -6367,7 +6373,7 @@ packages:
   /axios/1.3.2:
     resolution: {integrity: sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.2
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -6678,6 +6684,20 @@ packages:
       text-encoding-utf-8: 1.0.2
     dev: false
 
+  /boxen/5.1.2:
+    resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      cli-boxes: 2.2.1
+      string-width: 4.2.3
+      type-fest: 0.20.2
+      widest-line: 3.1.0
+      wrap-ansi: 7.0.0
+    dev: false
+
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -6962,6 +6982,11 @@ packages:
   /charenc/0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
 
+  /check-disk-space/3.3.1:
+    resolution: {integrity: sha512-iOrT8yCZjSnyNZ43476FE2rnssvgw5hnuwOM0hm8Nj1qa0v4ieUUEbCyxxsEliaoDUb/75yCOL71zkDiDBLbMQ==}
+    engines: {node: '>=12'}
+    dev: false
+
   /check-error/1.0.2:
     resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
 
@@ -7069,6 +7094,11 @@ packages:
   /clean-stack/2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
+
+  /cli-boxes/2.2.1:
+    resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
+    engines: {node: '>=6'}
+    dev: false
 
   /cli-cursor/3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -12347,7 +12377,7 @@ packages:
       '@corex/deepmerge': 4.0.37
       '@next/env': 13.1.6
       minimist: 1.2.7
-      next: 13.1.6_fcop3xylqakmbilfhdeuva2xj4
+      next: 13.1.6_pjwopsidmaokadturxaafygjp4
     dev: false
 
   /next/13.1.6_fcop3xylqakmbilfhdeuva2xj4:
@@ -12445,7 +12475,7 @@ packages:
       react: '>= 16.0.0'
     dependencies:
       '@types/nprogress': 0.2.0
-      next: 13.1.6_fcop3xylqakmbilfhdeuva2xj4
+      next: 13.1.6_pjwopsidmaokadturxaafygjp4
       nprogress: 0.2.0
       prop-types: 15.8.1
       react: 18.2.0
@@ -16223,6 +16253,13 @@ packages:
     dependencies:
       string-width: 2.1.1
     dev: true
+
+  /widest-line/3.1.0:
+    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
+    engines: {node: '>=8'}
+    dependencies:
+      string-width: 4.2.3
+    dev: false
 
   /wif/2.0.6:
     resolution: {integrity: sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ importers:
       '@nestjs/core': ^9.3.8
       '@nestjs/platform-fastify': ^9.3.8
       '@nestjs/schematics': ^9.0.4
+      '@nestjs/terminus': ^9.2.0
       '@nestjs/testing': ^9.3.8
       '@nestjs/throttler': ^3.1.0
       '@prisma/client': ^4.10.1
@@ -62,6 +63,7 @@ importers:
       '@nestjs/config': 2.3.1_6sysrfnceog466mrogtvxnbmxe
       '@nestjs/core': 9.3.8_6sysrfnceog466mrogtvxnbmxe
       '@nestjs/platform-fastify': 9.3.8_znlpu2ktzydjx7rl4llynpumdm
+      '@nestjs/terminus': 9.2.0_gricnmuqyfceqfz3faaorzr2oq
       '@nestjs/throttler': 3.1.0_566t3mhi5ibwmzfcn7izxal7e4
       '@prisma/client': 4.10.1_prisma@4.10.1
       '@waveshq/walletkit-core': 0.37.0
@@ -188,13 +190,13 @@ importers:
     devDependencies:
       '@birthdayresearch/eslint-config': 0.4.1_typescript@4.9.5
       '@birthdayresearch/sticky-testcontainers': 0.4.1
-      '@birthdayresearch/sticky-turbo-jest': 0.4.1_bq4te3ijfhoriehdxy7hzzdkwa
+      '@birthdayresearch/sticky-turbo-jest': 0.4.1_un5nppyspp2clu76j32bus6fcm
       '@birthdayresearch/sticky-typescript': 0.4.1
       '@ethersproject/abi': 5.7.0
       '@ethersproject/providers': 5.7.2
       '@nomicfoundation/hardhat-chai-matchers': 1.0.5_5h2wsktwjis7lmzn2zb7mgvahm
       '@nomicfoundation/hardhat-network-helpers': 1.0.8_hardhat@2.12.7
-      '@nomicfoundation/hardhat-toolbox': 2.0.1_ezsbf7xxshnemqyc3yls6tfeky
+      '@nomicfoundation/hardhat-toolbox': 2.0.1_xzk2pol7brjjszhuvmog5cd4o4
       '@openzeppelin/contracts': 4.8.0
       '@openzeppelin/contracts-upgradeable': 4.8.0
       '@typechain/ethers-v5': 10.2.0_kuvqdvnhbslgxdpi2awxjzdvhe
@@ -207,7 +209,7 @@ importers:
       ethers: 5.7.2
       hardhat: 2.12.7_6qtx7vkbdhwvdm4crzlegk4mvi
       mocha: 10.2.0
-      ts-node: 10.9.1_3fk7qfkuemqflumbj4dlt34bfa
+      ts-node: 10.9.1_qqdszkrtcshgbphghj7vnvrrby
 
 packages:
 
@@ -1522,27 +1524,6 @@ packages:
       - typescript
     dev: true
 
-  /@birthdayresearch/sticky-jest/0.4.1_bq4te3ijfhoriehdxy7hzzdkwa:
-    resolution: {integrity: sha512-atnTYWGPrn/iUBYA/zv4RSdz7bgEb3wBqMmvvDkeqcI4j0WCIRfhSt2BrvtlkDI86qoCNzXJiHfdnpgHe8Z3/A==}
-    dependencies:
-      '@types/jest': 29.4.0
-      jest: 29.4.2_k7quxe733nexnlgzi4yxvxoplq
-      jest-extended: 3.2.3_jest@29.4.2
-      ts-jest: 29.0.5_zgilbyuumz7xbrerspmrtjuxsi
-      wait-for-expect: 3.0.2
-      whatwg-fetch: 3.6.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@jest/types'
-      - '@types/node'
-      - babel-jest
-      - esbuild
-      - node-notifier
-      - supports-color
-      - ts-node
-      - typescript
-    dev: true
-
   /@birthdayresearch/sticky-jest/0.4.1_un5nppyspp2clu76j32bus6fcm:
     resolution: {integrity: sha512-atnTYWGPrn/iUBYA/zv4RSdz7bgEb3wBqMmvvDkeqcI4j0WCIRfhSt2BrvtlkDI86qoCNzXJiHfdnpgHe8Z3/A==}
     dependencies:
@@ -1597,23 +1578,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: true
-
-  /@birthdayresearch/sticky-turbo-jest/0.4.1_bq4te3ijfhoriehdxy7hzzdkwa:
-    resolution: {integrity: sha512-b9imnVM8IUCnP/wdWWCZdiiOOQHYDTdv5SjDvMc/PtZrpIWLgzlMXHh7vJng6EM/n1cpz07aGJgx8tU93ZqRjA==}
-    dependencies:
-      '@birthdayresearch/sticky-jest': 0.4.1_bq4te3ijfhoriehdxy7hzzdkwa
-      '@birthdayresearch/sticky-turbo': 0.4.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@jest/types'
-      - '@types/node'
-      - babel-jest
-      - esbuild
-      - node-notifier
-      - supports-color
-      - ts-node
-      - typescript
     dev: true
 
   /@birthdayresearch/sticky-turbo-jest/0.4.1_un5nppyspp2clu76j32bus6fcm:
@@ -2803,7 +2767,7 @@ packages:
       jest:
         optional: true
     dependencies:
-      jest: 29.4.2_k7quxe733nexnlgzi4yxvxoplq
+      jest: 29.4.2_qnch7tm6w36cvfoqlc3v7gbphu
       lodash: 4.17.21
       typescript: 4.9.5
       uuid: 7.0.3
@@ -3041,6 +3005,60 @@ packages:
     transitivePeerDependencies:
       - chokidar
     dev: true
+
+  /@nestjs/terminus/9.2.0_gricnmuqyfceqfz3faaorzr2oq:
+    resolution: {integrity: sha512-U3UR3qv3qY1i47JLxGQZfV8qkS4jlCtMWf/BJrUowSjNkBV/EkwOL9sUTHOROHPsEBZKjR6Ekwh9ymFARNhrfg==}
+    peerDependencies:
+      '@grpc/grpc-js': '*'
+      '@grpc/proto-loader': '*'
+      '@mikro-orm/core': '*'
+      '@mikro-orm/nestjs': '*'
+      '@nestjs/axios': '*'
+      '@nestjs/common': 9.x
+      '@nestjs/core': 9.x
+      '@nestjs/microservices': '*'
+      '@nestjs/mongoose': '*'
+      '@nestjs/sequelize': '*'
+      '@nestjs/typeorm': '*'
+      mongoose: '*'
+      reflect-metadata: 0.1.x
+      rxjs: 7.x
+      sequelize: '*'
+      typeorm: '*'
+    peerDependenciesMeta:
+      '@grpc/grpc-js':
+        optional: true
+      '@grpc/proto-loader':
+        optional: true
+      '@mikro-orm/core':
+        optional: true
+      '@mikro-orm/nestjs':
+        optional: true
+      '@nestjs/axios':
+        optional: true
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/mongoose':
+        optional: true
+      '@nestjs/sequelize':
+        optional: true
+      '@nestjs/typeorm':
+        optional: true
+      mongoose:
+        optional: true
+      sequelize:
+        optional: true
+      typeorm:
+        optional: true
+    dependencies:
+      '@nestjs/common': 9.3.8_welcnyot5bzd5wa2aovbkxpi4i
+      '@nestjs/core': 9.3.8_6sysrfnceog466mrogtvxnbmxe
+      boxen: 5.1.2
+      check-disk-space: 3.3.1
+      reflect-metadata: 0.1.13
+      rxjs: 7.8.0
+      typeorm: 0.3.12_pg@8.9.0+ts-node@10.9.1
+    dev: false
 
   /@nestjs/testing/9.3.8_znlpu2ktzydjx7rl4llynpumdm:
     resolution: {integrity: sha512-QyGOfrEOWbT8mi7ruYnh/taKuHDv4caAyf4WZ1YKkGn4tCeTKKNXSvV/y+NoO5o9Li/sLiq9B8EmleB1fxGajw==}
@@ -3667,7 +3685,7 @@ packages:
       hardhat: 2.12.7_6qtx7vkbdhwvdm4crzlegk4mvi
     dev: true
 
-  /@nomicfoundation/hardhat-toolbox/2.0.1_ezsbf7xxshnemqyc3yls6tfeky:
+  /@nomicfoundation/hardhat-toolbox/2.0.1_xzk2pol7brjjszhuvmog5cd4o4:
     resolution: {integrity: sha512-/pr8m9xlqiNlq6fXv4hEPNwdNwUhysoB2qbDCKqERfPpq34EydUQTC3Vis4aIea8RLwSrU8sDXFdv4TQxYstKw==}
     peerDependencies:
       '@ethersproject/abi': ^5.4.7
@@ -3700,13 +3718,13 @@ packages:
       '@typechain/hardhat': 6.1.5_oiikrsglaityxahgeoev6t5lpu
       '@types/chai': 4.3.4
       '@types/mocha': 10.0.1
-      '@types/node': 18.11.11
+      '@types/node': 18.11.19
       chai: 4.3.7
       ethers: 5.7.2
       hardhat: 2.12.7_6qtx7vkbdhwvdm4crzlegk4mvi
       hardhat-gas-reporter: 1.0.9_hardhat@2.12.7
       solidity-coverage: 0.8.2_hardhat@2.12.7
-      ts-node: 10.9.1_3fk7qfkuemqflumbj4dlt34bfa
+      ts-node: 10.9.1_qqdszkrtcshgbphghj7vnvrrby
       typechain: 8.1.1_gelezmms3va3pnkofxaadhcvma
       typescript: 4.9.5
     dev: true
@@ -4526,7 +4544,7 @@ packages:
   /@types/concat-stream/1.6.1:
     resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 18.11.19
     dev: true
 
   /@types/connect/3.4.35:
@@ -4588,14 +4606,14 @@ packages:
   /@types/form-data/0.0.33:
     resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 18.11.19
     dev: true
 
   /@types/glob/7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.11.11
+      '@types/node': 18.11.19
     dev: true
 
   /@types/glob/8.0.1:
@@ -4794,14 +4812,14 @@ packages:
   /@types/tar-fs/2.0.1:
     resolution: {integrity: sha512-qlsQyIY9sN7p221xHuXKNoMfUenOcvEBN4zI8dGsYbYCqHtTarXOEXSIgUnK+GcR0fZDse6pAIc5pIrCh9NefQ==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 18.11.19
       '@types/tar-stream': 2.2.2
     dev: false
 
   /@types/tar-stream/2.2.2:
     resolution: {integrity: sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 18.11.19
     dev: false
 
   /@types/trusted-types/2.0.2:
@@ -6373,7 +6391,7 @@ packages:
   /axios/1.3.2:
     resolution: {integrity: sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -10039,7 +10057,7 @@ packages:
       solc: 0.7.3_debug@4.3.4
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
-      ts-node: 10.9.1_3fk7qfkuemqflumbj4dlt34bfa
+      ts-node: 10.9.1_qqdszkrtcshgbphghj7vnvrrby
       tsort: 0.0.1
       typescript: 4.9.5
       undici: 5.18.0
@@ -10838,34 +10856,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /jest-cli/29.4.2_k7quxe733nexnlgzi4yxvxoplq:
-    resolution: {integrity: sha512-b+eGUtXq/K2v7SH3QcJvFvaUaCDS1/YAZBYz0m28Q/Ppyr+1qNaHmVYikOrbHVbZqYQs2IeI3p76uy6BWbXq8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.4.2_ts-node@10.9.1
-      '@jest/test-result': 29.4.2
-      '@jest/types': 29.4.2
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.1.0
-      jest-config: 29.4.2_k7quxe733nexnlgzi4yxvxoplq
-      jest-util: 29.4.2
-      jest-validate: 29.4.2
-      prompts: 2.4.2
-      yargs: 17.6.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: true
-
   /jest-cli/29.4.2_qnch7tm6w36cvfoqlc3v7gbphu:
     resolution: {integrity: sha512-b+eGUtXq/K2v7SH3QcJvFvaUaCDS1/YAZBYz0m28Q/Ppyr+1qNaHmVYikOrbHVbZqYQs2IeI3p76uy6BWbXq8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -11283,26 +11273,6 @@ packages:
       jest-util: 29.4.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  /jest/29.4.2_k7quxe733nexnlgzi4yxvxoplq:
-    resolution: {integrity: sha512-+5hLd260vNIHu+7ZgMIooSpKl7Jp5pHKb51e73AJU3owd5dEo/RfVwHbA/na3C/eozrt3hJOLGf96c7EWwIAzg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.4.2_ts-node@10.9.1
-      '@jest/types': 29.4.2
-      import-local: 3.1.0
-      jest-cli: 29.4.2_k7quxe733nexnlgzi4yxvxoplq
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: true
 
   /jest/29.4.2_qnch7tm6w36cvfoqlc3v7gbphu:
     resolution: {integrity: sha512-+5hLd260vNIHu+7ZgMIooSpKl7Jp5pHKb51e73AJU3owd5dEo/RfVwHbA/na3C/eozrt3hJOLGf96c7EWwIAzg==}
@@ -12377,7 +12347,7 @@ packages:
       '@corex/deepmerge': 4.0.37
       '@next/env': 13.1.6
       minimist: 1.2.7
-      next: 13.1.6_pjwopsidmaokadturxaafygjp4
+      next: 13.1.6_fcop3xylqakmbilfhdeuva2xj4
     dev: false
 
   /next/13.1.6_fcop3xylqakmbilfhdeuva2xj4:
@@ -12475,7 +12445,7 @@ packages:
       react: '>= 16.0.0'
     dependencies:
       '@types/nprogress': 0.2.0
-      next: 13.1.6_pjwopsidmaokadturxaafygjp4
+      next: 13.1.6_fcop3xylqakmbilfhdeuva2xj4
       nprogress: 0.2.0
       prop-types: 15.8.1
       react: 18.2.0
@@ -15482,6 +15452,7 @@ packages:
       typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /ts-node/10.9.1_qqdszkrtcshgbphghj7vnvrrby:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
       '@nestjs/config': 2.3.1_6hjtcnbswxd2r37etn7hs6457i
       '@nestjs/core': 9.3.8_6hjtcnbswxd2r37etn7hs6457i
       '@nestjs/platform-fastify': 9.3.8_znlpu2ktzydjx7rl4llynpumdm
-      '@nestjs/terminus': 9.2.0_gricnmuqyfceqfz3faaorzr2oq
+      '@nestjs/terminus': 9.2.0_22av745ilr65wxbh7m62vwshqa
       '@nestjs/throttler': 3.1.0_566t3mhi5ibwmzfcn7izxal7e4
       '@prisma/client': 4.10.1_prisma@4.10.1
       '@waveshq/walletkit-core': 0.37.0
@@ -211,7 +211,7 @@ importers:
       ethers: 5.7.2
       hardhat: 2.12.7_6qtx7vkbdhwvdm4crzlegk4mvi
       mocha: 10.2.0
-      ts-node: 10.9.1_qqdszkrtcshgbphghj7vnvrrby
+      ts-node: 10.9.1_3fk7qfkuemqflumbj4dlt34bfa
 
 packages:
 
@@ -2905,7 +2905,7 @@ packages:
       jest:
         optional: true
     dependencies:
-      jest: 29.4.2_qnch7tm6w36cvfoqlc3v7gbphu
+      jest: 29.4.2_k7quxe733nexnlgzi4yxvxoplq
       lodash: 4.17.21
       typescript: 4.9.5
       uuid: 7.0.3
@@ -3144,7 +3144,7 @@ packages:
       - chokidar
     dev: true
 
-  /@nestjs/terminus/9.2.0_gricnmuqyfceqfz3faaorzr2oq:
+  /@nestjs/terminus/9.2.0_22av745ilr65wxbh7m62vwshqa:
     resolution: {integrity: sha512-U3UR3qv3qY1i47JLxGQZfV8qkS4jlCtMWf/BJrUowSjNkBV/EkwOL9sUTHOROHPsEBZKjR6Ekwh9ymFARNhrfg==}
     peerDependencies:
       '@grpc/grpc-js': '*'
@@ -3189,12 +3189,12 @@ packages:
       typeorm:
         optional: true
     dependencies:
-      '@nestjs/common': 9.3.8_welcnyot5bzd5wa2aovbkxpi4i
-      '@nestjs/core': 9.3.8_6sysrfnceog466mrogtvxnbmxe
+      '@nestjs/common': 9.3.8_537f4dyna5eqdupcxnvaoq3vwa
+      '@nestjs/core': 9.3.8_6hjtcnbswxd2r37etn7hs6457i
       boxen: 5.1.2
       check-disk-space: 3.3.1
       reflect-metadata: 0.1.13
-      rxjs: 7.8.0
+      rxjs: 7.6.0
       typeorm: 0.3.12_pg@8.9.0+ts-node@10.9.1
     dev: false
 
@@ -3853,13 +3853,13 @@ packages:
       '@typechain/hardhat': 6.1.5_oiikrsglaityxahgeoev6t5lpu
       '@types/chai': 4.3.4
       '@types/mocha': 10.0.1
-      '@types/node': 18.11.19
+      '@types/node': 18.11.11
       chai: 4.3.7
       ethers: 5.7.2
       hardhat: 2.12.7_6qtx7vkbdhwvdm4crzlegk4mvi
       hardhat-gas-reporter: 1.0.9_hardhat@2.12.7
       solidity-coverage: 0.8.2_hardhat@2.12.7
-      ts-node: 10.9.1_qqdszkrtcshgbphghj7vnvrrby
+      ts-node: 10.9.1_3fk7qfkuemqflumbj4dlt34bfa
       typechain: 8.1.1_gelezmms3va3pnkofxaadhcvma
       typescript: 4.9.5
     dev: true
@@ -4880,7 +4880,7 @@ packages:
   /@types/concat-stream/1.6.1:
     resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
     dependencies:
-      '@types/node': 18.11.19
+      '@types/node': 18.11.11
     dev: true
 
   /@types/connect/3.4.35:
@@ -4942,14 +4942,14 @@ packages:
   /@types/form-data/0.0.33:
     resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
     dependencies:
-      '@types/node': 18.11.19
+      '@types/node': 18.11.11
     dev: true
 
   /@types/glob/7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.11.19
+      '@types/node': 18.11.11
     dev: true
 
   /@types/glob/8.0.0:
@@ -5145,14 +5145,14 @@ packages:
   /@types/tar-fs/2.0.1:
     resolution: {integrity: sha512-qlsQyIY9sN7p221xHuXKNoMfUenOcvEBN4zI8dGsYbYCqHtTarXOEXSIgUnK+GcR0fZDse6pAIc5pIrCh9NefQ==}
     dependencies:
-      '@types/node': 18.11.19
+      '@types/node': 18.11.11
       '@types/tar-stream': 2.2.2
     dev: false
 
   /@types/tar-stream/2.2.2:
     resolution: {integrity: sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==}
     dependencies:
-      '@types/node': 18.11.19
+      '@types/node': 18.11.11
     dev: false
 
   /@types/trusted-types/2.0.2:
@@ -6449,6 +6449,12 @@ packages:
 
   /anser/1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
+    dev: false
+
+  /ansi-align/3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+    dependencies:
+      string-width: 4.2.3
     dev: false
 
   /ansi-colors/3.2.3:
@@ -10826,7 +10832,7 @@ packages:
       solc: 0.7.3_debug@4.3.4
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
-      ts-node: 10.9.1_qqdszkrtcshgbphghj7vnvrrby
+      ts-node: 10.9.1_3fk7qfkuemqflumbj4dlt34bfa
       tsort: 0.0.1
       typescript: 4.9.5
       undici: 5.16.0
@@ -17290,7 +17296,6 @@ packages:
       typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /tsconfig-paths-webpack-plugin/4.0.0:
     resolution: {integrity: sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Create `/health` endpoint that will check database if the service is up.

UP response will be 
```
{
  "status": "ok",
  "info": {
    "database": {
      "status": "up"
    }
  },
  "error": {},
  "details": {}
  }
}
```

DOWN response will be
```
{
  "status": "error",
  "info": {},
  "error": {
    "database": {
      "status": "down",
       ...
    }
  },
  "details": {}
  }
}
```

#### Which issue(s) does this PR fixes?:

Fixes #365 

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
