### PR TITLE
fix(ui-ux): styling header and footer for smaller width

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -53,9 +53,9 @@ export default function Footer() {
     >
       <section
         data-testid="footer_web"
-        className="text-dark-900 xs:px-[24px] xs:pb-[51px] md:px-[48px] lg:px-[120px] lg:pb-[34px] text-sm"
+        className="text-dark-900 xs:px-[24px] px-5 pb-[51px] md:px-[48px] lg:px-[120px] lg:pb-[34px] text-sm"
       >
-        <div className="border-t-[0.5px] border-dark-300 xs:pb-[17.5px] pt-[15px]">
+        <div className="border-t-[0.5px] border-dark-300 pb-[17.5px] pt-[15px]">
           <div className="relative h-[28px] w-[250px] mt-3">
             <Image
               fill
@@ -70,15 +70,15 @@ export default function Footer() {
             Quantum is a proud development of Birthday Research — the blockchain
             R&D arm of Cake DeFi.
           </div>
-          <div className="flex flex-row justify-between xs:pt-[19px] md:pt-[26px] lg:pt-0">
-            <div className="flex xs:flex-col md:items-end md:flex-row md:flex item-start">
-              <div className="pr-[11px] md:pb-0 xs:pb-[12.5px]">
+          <div className="flex flex-row justify-between pt-[19px] md:pt-[26px] lg:pt-0">
+            <div className="flex flex-col md:flex-row md:items-end">
+              <div className="pb-2 pr-[11px] md:pb-0  xs:pb-[12.5px]">
                 &copy; Birthday Research
               </div>
               <Socials items={BirthdayResearchSocialItems} />
             </div>
             <div className="md:flex md:flex-row-reverse lg:flex-col lg:items-end lg:pt-0">
-              <div className="pb-0 md:pl-2 md:pb-0 xs:pb-[12.5px] lg:relative lg:bottom-[20px]">
+              <div className="pb-2 xs:pb-[12.5px] md:pl-2 md:pb-0 lg:relative lg:bottom-[20px]">
                 &copy; DeFiChain
               </div>
               <Socials items={DeFiChainSocialItems} />

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -9,7 +9,7 @@ export default function Header(): JSX.Element {
       <Banner />
       <div className="flex items-center justify-between px-5 pt-8 pb-6 md:px-10 md:py-6 lg:px-[120px] lg:pt-10 lg:pb-12">
         <Link href="/">
-          <div className="relative cursor-pointer xs:w-[85px] xs:h-[15px] md:-ml-1 lg:-ml-2 md:w-[132px] md:h-[24.5px] lg:h-[31.5px] lg:w-[170px]">
+          <div className="relative cursor-pointer w-[85px] h-[15px] md:-ml-1 lg:-ml-2 md:w-[132px] md:h-[24.5px] lg:h-[31.5px] lg:w-[170px]">
             <Image
               fill
               data-testid="header-bridge-logo"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Display header logo on smaller screens
<img width="353" alt="image" src="https://user-images.githubusercontent.com/44501120/219611671-4110292c-4bfb-4673-a0b5-1bb00564402c.png">

- Styling for footer on smaller screens
<img width="350" alt="image" src="https://user-images.githubusercontent.com/44501120/219611951-f91b9b20-6606-485d-ae46-416886ddce6b.png">


#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
