### PR TITLE
fix(core): multiple poll on consecutive transaction triggered

### DIFF
--- a/apps/web/src/hooks/useWatchEthTxn.ts
+++ b/apps/web/src/hooks/useWatchEthTxn.ts
@@ -13,13 +13,12 @@ export default function useWatchEthTxn() {
 
   const [confirmEthTxn] = useConfirmEthTxnMutation();
 
-  const [isApiLoading, setIsApiLoading] = useState(true);
   const [isApiSuccess, setIsApiSuccess] = useState(false);
   const [ethTxnStatus, setEthTxnStatus] = useState<{
     isConfirmed: boolean;
     numberOfConfirmations: string;
   }>({ isConfirmed: false, numberOfConfirmations: "0" });
-  var pollInterval;
+  let pollInterval;
 
   /* Poll to check if the txn is already confirmed */
   useEffect(() => {
@@ -44,20 +43,24 @@ export default function useWatchEthTxn() {
             isConfirmed: data?.isConfirmed,
             numberOfConfirmations: data?.numberOfConfirmations,
           });
-          setIsApiLoading(false);
           setIsApiSuccess(true);
         }
       } catch ({ data }) {
         if (data?.statusCode === HttpStatusCode.TooManyRequests) {
           //   handle throttle error;
         }
-        setIsApiLoading(false);
       }
     };
 
     if (pollInterval !== undefined) {
       clearInterval(pollInterval);
     }
+
+    // Run on load
+    if (!isApiSuccess) {
+      pollConfirmEthTxn(txnHash.unconfirmed);
+    }
+
     pollInterval = setInterval(() => {
       pollConfirmEthTxn(txnHash.unconfirmed);
     }, 20000);
@@ -69,5 +72,5 @@ export default function useWatchEthTxn() {
     };
   }, [networkEnv, txnHash]);
 
-  return { ethTxnStatus, isApiLoading, isApiSuccess };
+  return { ethTxnStatus, isApiSuccess };
 }

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -24,9 +24,7 @@ function Home() {
             <TransactionStatus
               onClose={() => setTxnHash("confirmed", null)}
               txnHash={txnHash.confirmed ?? txnHash.unconfirmed}
-              isConfirmed={
-                txnHash.confirmed !== undefined || ethTxnStatus.isConfirmed
-              }
+              isConfirmed={txnHash.confirmed !== undefined}
               numberOfConfirmations={
                 txnHash.confirmed !== undefined
                   ? CONFIRMATIONS_BLOCK_TOTAL.toString()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
This PR fixes multiple poll API `/handleTransaction` being triggered
When a transaction is confirmed, do not refresh/leave, proceed with new transaction
Should only have 1 `/handleTransaction` API triggered for new transaction

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
