### PR TITLE
feat(ui-ux): temporarily hide MainNet network

### DIFF
--- a/apps/web/cypress/e2e/bridge.spec.ts
+++ b/apps/web/cypress/e2e/bridge.spec.ts
@@ -9,7 +9,7 @@ describe("Bridge from Ethereum to DeFiChain", () => {
   it("should be able to bridge funds from Ethereum to DeFiChain", () => {
     cy.visit("http://localhost:3000");
     cy.findByTestId("amount").type("0.01").blur();
-    cy.findByTestId("network-env-switch").click().contains("TestNet");
+    cy.findByTestId("network-env-switch").click().contains("Playground"); // TODO: Replace `Playground` with `TestNet` once MainNet is ready
     cy.findByTestId("receiver-address").should("exist");
     cy.findByTestId("transfer-btn").should("exist");
     // TODO: Check confirm form fields

--- a/apps/web/src/components/EnvironmentNetworkSwitch.tsx
+++ b/apps/web/src/components/EnvironmentNetworkSwitch.tsx
@@ -16,10 +16,27 @@ export default function EnvironmentNetworkSwitch({
     let nextNetworkEnv: EnvironmentNetwork;
     switch (currentNetworkEnv) {
       case EnvironmentNetwork.TestNet:
+        nextNetworkEnv = EnvironmentNetwork.RemotePlayground;
+        break;
+      case EnvironmentNetwork.RemotePlayground:
+        nextNetworkEnv = EnvironmentNetwork.LocalPlayground;
+        break;
+      case EnvironmentNetwork.LocalPlayground:
+      default:
+        nextNetworkEnv = EnvironmentNetwork.TestNet;
+        break;
+    }
+
+    // TODO: Use this switch-statement once MainNet is ready
+    /* switch (currentNetworkEnv) {
+      case EnvironmentNetwork.TestNet:
         nextNetworkEnv =
           process.env.NODE_ENV === "production"
             ? EnvironmentNetwork.MainNet
-            : EnvironmentNetwork.LocalPlayground;
+            : EnvironmentNetwork.RemotePlayground;
+        break;
+      case EnvironmentNetwork.RemotePlayground:
+        nextNetworkEnv = EnvironmentNetwork.LocalPlayground;
         break;
       case EnvironmentNetwork.LocalPlayground:
         nextNetworkEnv = EnvironmentNetwork.MainNet;
@@ -29,6 +46,7 @@ export default function EnvironmentNetworkSwitch({
         nextNetworkEnv = EnvironmentNetwork.TestNet;
         break;
     }
+    */
     updateNetworkEnv(nextNetworkEnv);
     onChange();
   };

--- a/apps/web/src/layouts/Base.tsx
+++ b/apps/web/src/layouts/Base.tsx
@@ -34,11 +34,11 @@ import { ETHEREUM_MAINNET_ID } from "../constants";
 import { MAINNET_CONFIG, TESTNET_CONFIG } from "../config";
 
 const metamask = new MetaMaskConnector({
-  chains: [mainnet, goerli, localhost, hardhat],
+  chains: [goerli, localhost, hardhat], // TODO: Add `mainnet` here once MainNet is ready
 });
 
 const { chains } = configureChains(
-  [localhost, hardhat, mainnet, goerli],
+  [localhost, hardhat, goerli], // TODO: Add `mainnet` here once MainNet is ready
   [
     jsonRpcProvider({
       rpc: (chain) => {

--- a/apps/web/src/layouts/contexts/NetworkEnvironmentContext.tsx
+++ b/apps/web/src/layouts/contexts/NetworkEnvironmentContext.tsx
@@ -31,11 +31,19 @@ export function NetworkEnvironmentProvider({
   const networkQuery = router.query.network;
 
   function getNetwork(n: EnvironmentNetwork): EnvironmentNetwork {
+    if (env.networks.includes(n) && n !== EnvironmentNetwork.MainNet) {
+      return n;
+    }
+    return EnvironmentNetwork.TestNet;
+  }
+
+  // TODO: Use `getNetwork` fn below once MainNet is ready
+  /* function getNetwork(n: EnvironmentNetwork): EnvironmentNetwork {
     if (env.networks.includes(n)) {
       return n;
     }
     return EnvironmentNetwork.MainNet;
-  }
+  } */
 
   const initialNetwork = getNetwork(networkQuery as EnvironmentNetwork);
   const [networkEnv, setNetworkEnv] =


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Temporarily disable mainnet. User should not be able to connect wallet using Ethereum mainnet, or switch to MainNet from the UI

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
