### PR TITLE
fix(ui-ux): disable verify transfer when no address is generated

### DIFF
--- a/apps/web/src/components/erc-transfer/StepTwoSendConfirmation.tsx
+++ b/apps/web/src/components/erc-transfer/StepTwoSendConfirmation.tsx
@@ -268,7 +268,12 @@ export default function StepTwoSendConfirmation({
         <div className={clsx("hidden", "md:block")}>
           <div className="float-right mt-8">
             {/* Web confirm button */}
-            <VerifyButton onVerify={handleConfirmClick} />
+            <VerifyButton
+              onVerify={handleConfirmClick}
+              disabled={
+                addressGenerationError !== "" || dfcUniqueAddress === ""
+              }
+            />
           </div>
         </div>
       </div>
@@ -281,7 +286,10 @@ export default function StepTwoSendConfirmation({
       {/* Mobile confirm button */}
       <div className={clsx("order-last", "md:hidden")}>
         <div className={clsx("px-6 mt-12", "md:px-0")}>
-          <VerifyButton onVerify={handleConfirmClick} />
+          <VerifyButton
+            onVerify={handleConfirmClick}
+            disabled={addressGenerationError !== "" || dfcUniqueAddress === ""}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
To disable verify transfer button when no address is generated

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
