### PR TITLE
feat(ui-ux): handle error when contract has insufficient balance

### DIFF
--- a/apps/web/src/components/commons/ErrorModal.tsx
+++ b/apps/web/src/components/commons/ErrorModal.tsx
@@ -20,7 +20,7 @@ export default function ErrorModal({
       <div className="flex flex-col items-center mt-6 mb-14">
         <FiAlertCircle className="text-8xl text-error ml-1" />
         <span className="font-bold text-2xl text-dark-900 mt-12">{title}</span>
-        <div className="w-full text-dark-900 text-center break-all mt-2 px-[29px]">
+        <div className="w-full text-dark-900 text-center break-word mt-2 px-[29px]">
           {message}
         </div>
         <span className="pt-12">

--- a/apps/web/src/components/erc-transfer/StepLastClaim.tsx
+++ b/apps/web/src/components/erc-transfer/StepLastClaim.tsx
@@ -106,8 +106,8 @@ export default function StepLastClaim({
           new BigNumber(contractBalance)
         );
         setIsBalanceInsufficient(isInsufficient);
-      } catch (error) {
-        Logging.error(error);
+      } catch (e) {
+        Logging.error(e);
       }
     }
     checkBalance();

--- a/apps/web/src/components/erc-transfer/StepLastClaim.tsx
+++ b/apps/web/src/components/erc-transfer/StepLastClaim.tsx
@@ -17,6 +17,8 @@ import { SignedClaim, TransferData } from "types";
 import UtilityButton from "@components/commons/UtilityButton";
 import useTransferFee from "@hooks/useTransferFee";
 import { useStorageContext } from "@contexts/StorageContext";
+import { useBalanceEvmMutation } from "@store/index";
+import Logging from "@api/logging";
 
 const CLAIM_INPUT_ERROR =
   "Check your connection and try again.  If the error persists get in touch with us.";
@@ -31,6 +33,8 @@ export default function StepLastClaim({
   const router = useRouter();
   const [showLoader, setShowLoader] = useState(false);
   const [error, setError] = useState<string>();
+  const [balanceEvm] = useBalanceEvmMutation();
+  const [isBalanceInsufficient, setIsBalanceInsufficient] = useState(false);
 
   const { BridgeV1, Erc20Tokens, ExplorerURL } = useContractContext();
   const tokenAddress = Erc20Tokens[data.to.tokenName].address;
@@ -91,6 +95,31 @@ export default function StepLastClaim({
   useEffect(() => {
     setError(writeClaimTxnError?.message ?? claimTxnError?.message);
   }, [writeClaimTxnError, claimTxnError]);
+
+  useEffect(() => {
+    async function checkBalance() {
+      try {
+        const contractBalance = await balanceEvm({
+          tokenSymbol: data.to.tokenName.toUpperCase(),
+        }).unwrap();
+        const isInsufficient = data.to.amount.isGreaterThan(
+          new BigNumber(contractBalance)
+        );
+        setIsBalanceInsufficient(isInsufficient);
+      } catch (error) {
+        Logging.error(error);
+      }
+    }
+    checkBalance();
+  }, []);
+
+  useEffect(() => {
+    if (error && isBalanceInsufficient) {
+      setError(
+        "Quantum's servers are currently at capacity. We are unable to process transactions at this time, please try again in a few hours to claim your tokens."
+      );
+    }
+  }, [error, isBalanceInsufficient]);
 
   return (
     <>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
As titled. Since smartcontract is not able to return specific error, we will use our `/balance` api to get the balance from the Ethereum side, and check against it to see if the transfer amount is greater.

#### Which issue(s) does this PR fixes?:
https://github.com/WavesHQ/bridge/issues/525

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
