### PR TITLE
fix(core): web - fix sudden odd display of approval loader

### DIFF
--- a/apps/web/src/hooks/useWriteBridgeToDeFiChain.ts
+++ b/apps/web/src/hooks/useWriteBridgeToDeFiChain.ts
@@ -14,7 +14,7 @@ import { useContractContext } from "@contexts/ContractContext";
 import { Erc20Token } from "types";
 import { ETHEREUM_SYMBOL } from "../constants";
 
-interface EventErrorI {
+export interface EventErrorI {
   customErrorDisplay?:
     | "InsufficientAllowanceError"
     | "UserRejectedRequestError";
@@ -27,6 +27,7 @@ interface BridgeToDeFiChainI {
   tokenName: Erc20Token;
   tokenDecimals: number | "gwei";
   onBridgeTxnSettled: () => void;
+  setEventError: (error: EventErrorI | undefined) => void;
 }
 
 export default function useWriteBridgeToDeFiChain({
@@ -35,10 +36,10 @@ export default function useWriteBridgeToDeFiChain({
   tokenName,
   tokenDecimals,
   onBridgeTxnSettled,
+  setEventError,
 }: BridgeToDeFiChainI) {
   const { BridgeV1, Erc20Tokens } = useContractContext();
   const sendingFromETH = (tokenName as string) === ETHEREUM_SYMBOL;
-  const [eventError, setEventError] = useState<EventErrorI>();
   const [requiresApproval, setRequiresApproval] = useState(false);
 
   const handlePrepContractError = (err) => {
@@ -123,6 +124,5 @@ export default function useWriteBridgeToDeFiChain({
     writeBridgeToDeFiChain,
     transactionHash: bridgeContract?.hash,
     requiresApproval,
-    eventError,
   };
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Fix approval loader that is suddenly displayed when manually resetting the spending limit.
Related to changes in this [PR](https://github.com/WavesHQ/bridge/pull/569)

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #568 (related fix)

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
