### PR TITLE
fix(api): ETH Stats - Anchor dateTo with dateFrom and not today (bug)

### DIFF
--- a/apps/server/src/ethereum/services/EthereumStatsService.ts
+++ b/apps/server/src/ethereum/services/EthereumStatsService.ts
@@ -27,7 +27,7 @@ export class EthereumStatsService {
       }
 
       dateFrom.setUTCHours(0, 0, 0, 0); // set to UTC +0
-      const dateTo = new Date(today);
+      const dateTo = new Date(dateFrom);
       dateTo.setDate(dateFrom.getDate() + 1);
 
       // Concurrently query both count and confirmed txns


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it: 

1. Caused by typo `const dateTo = new Date(today);` where `today` should have been `dateFrom`
2. Does not affect DFI

#### Which issue(s) does this PR fixes?:

Fixes https://github.com/WavesHQ/quantum-admin/issues/79

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
